### PR TITLE
Broaden the lock to include GetEntity. It allows 1 thread to execute …

### DIFF
--- a/Pipelines/Blocks/GetNextCounterValueBlock.cs
+++ b/Pipelines/Blocks/GetNextCounterValueBlock.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Booker.Commerce.Plugins.Order
+namespace  Sitecore.Commerce.Plugin.Ordernumber.Pipelines.Blocks
 {
     public class GetNextCounterValueBlock : PipelineBlock<GetNextCounterValueArgument, long, CommercePipelineExecutionContext>
     {


### PR DESCRIPTION
…the code.